### PR TITLE
fix Concurrent modification error

### DIFF
--- a/lib/src/channels/socketio/socketio_channel.dart
+++ b/lib/src/channels/socketio/socketio_channel.dart
@@ -87,7 +87,7 @@ class SocketIoChannel extends Channel {
   }
 
   /// Unbind the channel's socket from all stored event callbacks.
-  void unbind() => events.keys.forEach((event) {
+  void unbind() => Map.from(events).keys.forEach((event) {
         _unbindEvent(event);
       });
 


### PR DESCRIPTION
description:
There is an issue when trying to leave a channel: an array element is beeing removed while iterating that same array causing this error:
`Concurrent modification during iteration`

detail:
- line 90 is iterating `events` which calls `_unbindEvent` on each iteration
- line 107 of `_unbindEvent` calls `events.remove(event);` which causes the error since its called during iteration

fix:
its fixed by iterating a **copy** of `events` instead of the original

