### PR TITLE
fix for pusher_client_socket 0.0.6

### DIFF
--- a/lib/src/connector/pusher_connector.dart
+++ b/lib/src/connector/pusher_connector.dart
@@ -41,7 +41,7 @@ class PusherConnector extends Connector<PUSHER.PusherClient, PusherChannel> {
                 key: key,
                 authOptions: PUSHER.PusherAuthOptions(
                   authEndPoint,
-                  headers: authHeaders,
+                  headers: () async => authHeaders,
                 ),
                 cluster: cluster,
                 channelDecryption: channelDecryption,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
     sdk: flutter
   meta: ^1.16.0
   pinenacl: ^0.6.0
-  pusher_client_socket: ^0.0.5
+  pusher_client_socket: ^0.0.6
   socket_io_client: ^3.1.0+2
 
 dev_dependencies:


### PR DESCRIPTION
new version of pusher_client_socket has a breaking change accepting function instead of value for headers
this pr should fix it

See here: https://github.com/AbdoPrDZ/pusher_client_socket/pull/5